### PR TITLE
[fix]trend_metricsの出力を色々と調整できるように修正

### DIFF
--- a/src/analysis/trend_metrics/utils/constants.py
+++ b/src/analysis/trend_metrics/utils/constants.py
@@ -5,31 +5,50 @@ Trend Metrics Analysis用の定数定義
 
 # 分析対象プロジェクトとリリース
 TREND_ANALYSIS_CONFIG = {
-    'project': 'nova',
-    'release': [
-        '12.0.0',
-        '13.0.0',
-        '14.0.0',
-        '15.0.0',
-        '16.0.0',
-        '17.0.0',
-        '18.0.0',
-        '19.0.0',
-        '20.0.0',
-        '21.0.0',
-        '22.0.0',
-        '23.0.0',
-        '24.0.0',
-        '25.0.0',
-        '26.0.0',
-        '27.0.0',
-        '28.0.0',
-        '29.0.0',
-        '30.0.0'
-    ]
+    'project': {
+        'nova': [
+            '12.0.0',
+            '13.0.0',
+            '14.0.0',
+            '15.0.0',
+            '16.0.0',
+            '17.0.0',
+            '18.0.0',
+            '19.0.0',
+            '20.0.0',
+            '21.0.0',
+            '22.0.0',
+            '23.0.0',
+            '24.0.0',
+            '25.0.0',
+            '26.0.0',
+            '27.0.0',
+            '28.0.0',
+            '29.0.0',
+            '30.0.0'
+        ]
+    }
 }
 
+# TREND_ANALYSIS_CONFIG = {
+#     'project': {
+#         'nova': [
+#             '12.0.0',
+#             '13.0.0',
+#         ]
+#     }
+# }
+
 # 分析期間の定義（日数）
+# 期間定義方法の選択
+# 'fixed_days': 固定日数（例：30日）で区切る（ANALYSIS_PERIODSの設定を使用）
+# 'split_ratio': リリース間隔を等分割して区切る（PERIOD_SPLIT_RATIOを使用）
+PERIOD_DEFINITION_METHOD = 'fixed_days'
+
+# 分割数（PERIOD_DEFINITION_METHOD = 'split_ratio' の場合に使用）
+# 例: 6 の場合、リリース間隔を6等分し、最初の1つを前期、最後の1つを後期とする
+PERIOD_SPLIT_RATIO = 6
+
 ANALYSIS_PERIODS = {
     'early': {
         'base_date': 'current_release',  # 基準日：現在のリリース日
@@ -45,41 +64,67 @@ ANALYSIS_PERIODS = {
     }
 }
 
-# レビューアタイプの定義
-REVIEWER_TYPES = {
-    'core_reviewed': {
-        'label': 'core_reviewed',
-        'description': 'コアレビューアがレビューした',
-        'condition': 'has_core_review == True'
-    },
-    'core_not_reviewed': {
-        'label': 'core_not_reviewed',
-        'description': 'コアレビューアがレビューしていない',
-        'condition': 'has_core_review == False'
-    },
-    'non_core_reviewed': {
-        'label': 'non_core_reviewed',
-        'description': '非コアレビューアのみがレビューした',
-        'condition': 'has_core_review == False and has_non_core_review == True'
-    },
-    'non_core_not_reviewed': {
-        'label': 'non_core_not_reviewed',
-        'description': '誰もレビューしていない',
-        'condition': 'has_core_review == False and has_non_core_review == False'
-    }
-}
+# コアレビューアと非コアレビューアを区別するかどうか
+SEPARATE_CORE_REVIEWERS = False
 
-# 分析グループの定義（期間 × レビューアタイプ）
-ANALYSIS_GROUPS = [
-    'early_core_reviewed',
-    'early_core_not_reviewed',
-    'early_non_core_reviewed',
-    'early_non_core_not_reviewed',
-    'late_core_reviewed',
-    'late_core_not_reviewed',
-    'late_non_core_reviewed',
-    'late_non_core_not_reviewed'
-]
+if SEPARATE_CORE_REVIEWERS:
+    # レビューアタイプの定義
+    REVIEWER_TYPES = {
+        'core_reviewed': {
+            'label': 'core_reviewed',
+            'description': 'コアレビューアがレビューした',
+            'condition': 'has_core_review == True'
+        },
+        'core_not_reviewed': {
+            'label': 'core_not_reviewed',
+            'description': 'コアレビューアがレビューしていない',
+            'condition': 'has_core_review == False'
+        },
+        'non_core_reviewed': {
+            'label': 'non_core_reviewed',
+            'description': '非コアレビューアのみがレビューした',
+            'condition': 'has_core_review == False and has_non_core_review == True'
+        },
+        'non_core_not_reviewed': {
+            'label': 'non_core_not_reviewed',
+            'description': '誰もレビューしていない',
+            'condition': 'has_core_review == False and has_non_core_review == False'
+        }
+    }
+
+    # 分析グループの定義（期間 × レビューアタイプ）
+    ANALYSIS_GROUPS = [
+        'early_core_reviewed',
+        'early_core_not_reviewed',
+        'early_non_core_reviewed',
+        'early_non_core_not_reviewed',
+        'late_core_reviewed',
+        'late_core_not_reviewed',
+        'late_non_core_reviewed',
+        'late_non_core_not_reviewed'
+    ]
+else:
+    # レビューアタイプの定義（区別しない場合）
+    REVIEWER_TYPES = {
+        'reviewed': {
+            'label': 'reviewed',
+            'description': 'レビューされた',
+            'condition': 'has_core_review == True or has_non_core_review == True'
+        },
+        'not_reviewed': {
+            'label': 'not_reviewed',
+            'description': 'レビューされていない',
+            'condition': 'has_core_review == False and has_non_core_review == False'
+        }
+    }
+
+    # 分析グループの定義（期間 × レビューアタイプ）
+    ANALYSIS_GROUPS = [
+        'early_reviewed',
+        'early_not_reviewed',
+        'late_reviewed',
+        'late_not_reviewed'
+    ]
 
 # メトリクス一覧
 METRIC_COLUMNS = [

--- a/src/analysis/trend_metrics/visualization/__init__.py
+++ b/src/analysis/trend_metrics/visualization/__init__.py
@@ -2,11 +2,12 @@
 Visualization module for Trend Metrics Analysis
 """
 from .trend_plotter import plot_boxplots_8groups, plot_trend_lines, plot_metric_changes
-from .heatmap_generator import generate_heatmap
+from .heatmap_generator import generate_heatmap, generate_aggregated_heatmap
 
 __all__ = [
     'plot_boxplots_8groups',
     'plot_trend_lines',
     'plot_metric_changes',
-    'generate_heatmap'
+    'generate_heatmap',
+    'generate_aggregated_heatmap'
 ]

--- a/src/analysis/trend_metrics/visualization/heatmap_generator.py
+++ b/src/analysis/trend_metrics/visualization/heatmap_generator.py
@@ -162,3 +162,275 @@ def generate_heatmap(
     logger.info(f"効果量ヒートマップを生成しました: {output_path_es}")
     
     return output_path
+
+
+def generate_aggregated_heatmap(
+    overall_results: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]],
+    output_dir: Path,
+    metric_filter: List[str] = None,
+    alpha: float = 0.05
+) -> Path:
+    """
+    全リリースの統計検定結果（p値、効果量）をまとめたヒートマップテーブルを生成
+    Early vs Late の比較に特化して表示する
+    
+    複数のテーブルを生成:
+    1. 統合版（Reviewed + Not Reviewed）
+    2. Reviewed のみ
+    3. Not Reviewed のみ
+    
+    Args:
+        overall_results: {release: {metric: {pair: {'p_value': ..., 'effect_size': ...}}}}
+        output_dir: 出力ディレクトリ
+        metric_filter: 可視化対象メトリクスのリスト
+        alpha: 有意水準
+        
+    Returns:
+        Path: 生成された画像ファイルのパス（統合版）
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    releases = list(overall_results.keys())
+    
+    # 全てのメトリクスを収集（順序を保持）
+    all_metrics = []
+    metrics_seen = set()
+    for release in releases:
+        res_release = overall_results[release]
+        for metric in res_release.keys():
+            if metric_filter and metric not in metric_filter:
+                continue
+            if metric not in metrics_seen:
+                all_metrics.append(metric)
+                metrics_seen.add(metric)
+    sorted_metrics = all_metrics
+
+    # 1. 統合版テーブルを生成
+    target_pairs_combined = {
+        'early_reviewed_vs_late_reviewed': 'Reviewed',
+        'early_not_reviewed_vs_late_not_reviewed': 'Not Reviewed'
+    }
+    output_path_combined = _generate_single_heatmap(
+        overall_results, releases, sorted_metrics, target_pairs_combined,
+        output_dir, 'aggregated_heatmap_table.pdf', 
+        "Early vs Late Comparison (p-values & Effect Sizes)", alpha
+    )
+    
+    # 2. Reviewed のみのテーブルを生成
+    target_pairs_reviewed = {
+        'early_reviewed_vs_late_reviewed': 'Reviewed'
+    }
+    _generate_single_heatmap(
+        overall_results, releases, sorted_metrics, target_pairs_reviewed,
+        output_dir, 'aggregated_heatmap_table_reviewed.pdf',
+        "Early vs Late Comparison - Reviewed Only", alpha
+    )
+    
+    # 3. Not Reviewed のみのテーブルを生成
+    target_pairs_not_reviewed = {
+        'early_not_reviewed_vs_late_not_reviewed': 'Not Reviewed'
+    }
+    _generate_single_heatmap(
+        overall_results, releases, sorted_metrics, target_pairs_not_reviewed,
+        output_dir, 'aggregated_heatmap_table_not_reviewed.pdf',
+        "Early vs Late Comparison - Not Reviewed Only", alpha
+    )
+    
+    return output_path_combined
+
+
+def _generate_single_heatmap(
+    overall_results: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]],
+    releases: List[str],
+    sorted_metrics: List[str],
+    target_pairs: Dict[str, str],
+    output_dir: Path,
+    filename: str,
+    title: str,
+    alpha: float = 0.05
+) -> Path:
+    """
+    単一のヒートマップテーブルを生成するヘルパー関数
+    
+    Args:
+        overall_results: 全リリースの統計検定結果
+        releases: リリースのリスト
+        sorted_metrics: ソート済みメトリクスのリスト
+        target_pairs: 表示対象のペア定義 {pair_key: label}
+        output_dir: 出力ディレクトリ
+        filename: 出力ファイル名
+        title: グラフタイトル
+        alpha: 有意水準
+        
+    Returns:
+        Path: 生成された画像ファイルのパス
+    """
+    # 列の定義 (Metric -> Category -> Stat)
+    columns = []
+    for metric in sorted_metrics:
+        for pair_key, pair_label in target_pairs.items():
+            columns.append((metric, pair_label, 'p-value'))
+            columns.append((metric, pair_label, 'effect_size'))
+            
+    # データ埋め込み
+    data = []
+    for release in releases:
+        row = []
+        for metric in sorted_metrics:
+            for pair_key, pair_label in target_pairs.items():
+                # 値の取得
+                val_dict = overall_results.get(release, {}).get(metric, {}).get(pair_key, {})
+                p_val = val_dict.get('p_value', np.nan)
+                es = val_dict.get('effect_size', np.nan)
+                
+                row.append(p_val)
+                row.append(es)
+        data.append(row)
+        
+    if not data:
+        logger.warning("集約ヒートマップ用のデータがありません")
+        return None
+
+    # DataFrame作成
+    df = pd.DataFrame(data, index=releases, columns=pd.MultiIndex.from_tuples(columns, names=['Metric', 'Category', 'Stat']))
+    
+    # プロット描画
+    cell_width = 1.2
+    cell_height = 0.6
+    
+    n_rows = len(releases)
+    n_cols = len(columns)
+    
+    width = max(n_cols * cell_width + 2, 10)
+    height = max(n_rows * cell_height + 4, 6)
+    
+    fig, ax = plt.subplots(figsize=(width, height))
+    
+    # 軸の設定
+    ax.set_xlim(0, n_cols)
+    ax.set_ylim(0, n_rows)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.invert_yaxis()
+    
+    # カラーマップ
+    cmap_p = plt.cm.Reds
+    cmap_es = plt.cm.Blues
+    
+    # 描画ループ
+    for i, release in enumerate(releases):
+        # 行ラベル (リリース名)
+        ax.text(-0.2, i + 0.5, release, ha='right', va='center', fontweight='bold', fontsize=11)
+        
+        for j, col_tuple in enumerate(columns):
+            metric, category, stat_type = col_tuple
+            val = df.iloc[i, j]
+            
+            if pd.isna(val):
+                color = 'white'
+                text_val = "-"
+            else:
+                if stat_type == 'p-value':
+                    if val > alpha:
+                        color = 'white'
+                    else:
+                        norm_val = 1.0 - (val / alpha)
+                        norm_val = 0.2 + 0.8 * norm_val
+                        color = cmap_p(norm_val)
+                    
+                    text_val = f"{val:.3f}"
+                    if val < 0.001:
+                        text_val = "<.001"
+                        
+                else: # effect_size
+                    norm_val = min(abs(val), 1.0)
+                    color = cmap_es(norm_val)
+                    text_val = f"{val:.2f}"
+            
+            # セルの描画
+            rect = plt.Rectangle((j, i), 1, 1, facecolor=color, edgecolor='gray', linewidth=0.5)
+            ax.add_patch(rect)
+            
+            # テキスト描画
+            text_color = 'black'
+            if stat_type == 'effect_size' and abs(val) > 0.5:
+                text_color = 'white'
+            if stat_type == 'p-value' and val < 0.01:
+                text_color = 'white'
+                
+            ax.text(j + 0.5, i + 0.5, text_val, ha='center', va='center', color=text_color, fontsize=9)
+
+    # ヘッダー描画
+    # Metric (最上段)
+    current_metric = None
+    start_col = 0
+    header_y_metric = -1.8
+    header_y_category = -1.0
+    header_y_stat = -0.3
+    
+    for j, col_tuple in enumerate(columns):
+        metric = col_tuple[0]
+        if metric != current_metric:
+            if current_metric is not None:
+                center = (start_col + j) / 2
+                ax.text(center, header_y_metric, current_metric, ha='center', va='center', fontweight='bold', fontsize=11)
+                # メトリクス区切り線
+                ax.plot([j, j], [header_y_metric - 0.5, n_rows], color='black', linewidth=1.5)
+            
+            current_metric = metric
+            start_col = j
+            
+    # 最後のメトリクス
+    center = (start_col + n_cols) / 2
+    ax.text(center, header_y_metric, current_metric, ha='center', va='center', fontweight='bold', fontsize=11)
+
+    # Category (2段目: Reviewed / Not Reviewed)
+    current_category = None
+    cat_start_col = 0
+    for j, col_tuple in enumerate(columns):
+        category = col_tuple[1]
+        # カテゴリが変わるか、メトリクスが変わったら描画
+        if category != current_category or (j > 0 and columns[j][0] != columns[j-1][0]):
+            if current_category is not None and (j > cat_start_col):
+                center = (cat_start_col + j) / 2
+                ax.text(center, header_y_category, current_category, ha='center', va='center', fontsize=10)
+                # カテゴリ区切り線
+                ax.plot([j, j], [header_y_category - 0.3, n_rows], color='gray', linewidth=1.0)
+            
+            current_category = category
+            cat_start_col = j
+            
+    # 最後のカテゴリ
+    center = (cat_start_col + n_cols) / 2
+    ax.text(center, header_y_category, current_category, ha='center', va='center', fontsize=10)
+
+    # Stat (3段目: p-value / effect size)
+    for j, col_tuple in enumerate(columns):
+        stat_type = col_tuple[2]
+        label = "p-value" if stat_type == 'p-value' else "effect size"
+        ax.text(j + 0.5, header_y_stat, label, ha='center', va='center', fontsize=9)
+        # Stat区切り線
+        if j > 0:
+             ax.plot([j, j], [0, n_rows], color='lightgray', linewidth=0.5)
+
+    # 外枠
+    ax.plot([0, n_cols], [0, 0], color='black', linewidth=1.5)
+    ax.plot([0, n_cols], [n_rows, n_rows], color='black', linewidth=1.5)
+    ax.plot([0, 0], [header_y_metric - 0.5, n_rows], color='black', linewidth=1.5)
+    ax.plot([n_cols, n_cols], [header_y_metric - 0.5, n_rows], color='black', linewidth=1.5)
+    
+    # ヘッダーの横線
+    ax.plot([0, n_cols], [header_y_category - 0.4, header_y_category - 0.4], color='black', linewidth=1) # Metricの下
+    ax.plot([0, n_cols], [header_y_stat - 0.4, header_y_stat - 0.4], color='gray', linewidth=1) # Categoryの下
+
+    plt.title(title, y=1.2, fontsize=14)
+    
+    # 余白調整
+    plt.subplots_adjust(left=0.15, right=0.98, top=0.8, bottom=0.05)
+    
+    output_path = output_dir / filename
+    plt.savefig(output_path, dpi=300, bbox_inches='tight')
+    plt.close()
+    
+    logger.info(f"集約ヒートマップテーブルを生成しました: {output_path}")
+    return output_path


### PR DESCRIPTION
- マージされたChangeについて，どのバージョンでリリースされたのかを正確に紐づけるコードを作成
- バージョンを全て含めて分析していたのを，バージョンごとに分析を行うように修正
- コア・非コア開発者を分けて分析する or しないを設定できるように修正
- p値・効果量の算出時には，一つの要素しかことならない組み合わせ以外分析しないように修正
- リリースからの距離については1ヶ月などの定数値をおくことも，リリースの1/6の期間という変数値をおくことも可能なように修正
- 前期・後期だけの比較をした表を出力するコードを作成